### PR TITLE
Restore sheet music contrast

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -406,9 +406,13 @@ main {
 .musical-staff {
     border-radius: var(--radius-md);
     padding: var(--spacing-lg);
-    background: linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.82));
-    border: 1px solid rgba(59, 130, 246, 0.25);
-    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08), 0 18px 35px rgba(2, 6, 23, 0.6);
+    background: #ffffff;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    box-shadow: 0 18px 35px rgba(2, 6, 23, 0.18);
+}
+
+.musical-staff #musicalstaff svg {
+    width: 100%;
 }
 
 .vexbox {


### PR DESCRIPTION
## Summary
- reset the musical staff container to a white background with a subtle border and softer shadow for readability
- ensure the rendered VexFlow SVG expands to the full staff width so the white backdrop fills the area

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_690a22590b2c8324ab75045c9c23cb8b