### PR TITLE
Adjust workspace layout to full-width arrangement

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,8 +42,8 @@
         </section>
 
         <section class="app-grid" aria-label="Jingle creation workspace">
-            <aside class="controls-column" aria-label="Settings and controls">
-                <div class="glass-card params-summary" role="status" aria-live="polite">
+            <section class="glass-card params-panel" aria-label="Settings and controls" role="status" aria-live="polite">
+                <div class="params-bar">
                     <div class="params-display">
                         <span class="param-item">Scale: <strong id="scale-display">C Major</strong></span>
                         <span class="param-item">Tempo: <strong id="tempo-display">120</strong> BPM</span>
@@ -54,91 +54,87 @@
                     <button id="toggle-settings" class="settings-toggle" aria-expanded="false">⚙️ Settings</button>
                 </div>
 
-                <section class="glass-card controls-shell" aria-label="Detailed settings">
-                    <div class="controls-container" id="controls-container" style="display: none;">
-                        <div class="control-section">
-                            <h3>Musical Settings</h3>
-                            <div class="control-group">
-                                <div class="control-item">
-                                    <label for="scale">Scale</label>
-                                    <select id="scale"></select>
-                                </div>
-                                <div class="control-item">
-                                    <label for="tempo">Tempo (BPM)</label>
-                                    <input type="number" id="tempo" value="120" min="20" max="300">
-                                </div>
-                                <div class="control-item">
-                                    <label for="numNotesMax">Max # Notes</label>
-                                    <input type="number" id="numNotesMax" value="6" min="2" max="20">
-                                </div>
-                                <div class="control-item">
-                                    <label for="timeSignature">Time Signature</label>
-                                    <select id="timeSignature" disabled="true">
-                                        <option value="4/4">4/4</option>
-                                        <option value="3/4">3/4</option>
-                                        <option value="2/4">2/4</option>
-                                        <option value="6/8">6/8</option>
-                                    </select>
-                                </div>
-                                <div class="control-item checkbox-item">
-                                    <input type="checkbox" id="include32ndNotes" name="include32ndNotes">
-                                    <label for="include32ndNotes">Include 32nd Notes</label>
-                                </div>
+                <div class="controls-container" id="controls-container" style="display: none;">
+                    <div class="control-section">
+                        <h3>Musical Settings</h3>
+                        <div class="control-group">
+                            <div class="control-item">
+                                <label for="scale">Scale</label>
+                                <select id="scale"></select>
                             </div>
-                        </div>
-
-                        <div class="control-section">
-                            <h3>Audio Settings</h3>
-                            <div class="control-group">
-                                <div class="control-item">
-                                    <label for="synthType">Synthesizer</label>
-                                    <select id="synthType">
-                                        <option value="Synth">Synth</option>
-                                        <option value="AMSynth">AMSynth</option>
-                                        <option value="FMSynth">FMSynth</option>
-                                        <option value="MonoSynth">MonoSynth</option>
-                                        <option value="DuoSynth">DuoSynth</option>
-                                        <option value="MetalSynth">MetalSynth</option>
-                                    </select>
-                                </div>
-                                <div class="control-item">
-                                    <label for="oscillatorType">Oscillator</label>
-                                    <select id="oscillatorType">
-                                        <option value="sine">sine</option>
-                                        <option value="square">square</option>
-                                        <option value="triangle">triangle</option>
-                                        <option value="sawtooth">sawtooth</option>
-                                        <option value="pwm">pwm</option>
-                                    </select>
-                                </div>
+                            <div class="control-item">
+                                <label for="tempo">Tempo (BPM)</label>
+                                <input type="number" id="tempo" value="120" min="20" max="300">
+                            </div>
+                            <div class="control-item">
+                                <label for="numNotesMax">Max # Notes</label>
+                                <input type="number" id="numNotesMax" value="6" min="2" max="20">
+                            </div>
+                            <div class="control-item">
+                                <label for="timeSignature">Time Signature</label>
+                                <select id="timeSignature" disabled="true">
+                                    <option value="4/4">4/4</option>
+                                    <option value="3/4">3/4</option>
+                                    <option value="2/4">2/4</option>
+                                    <option value="6/8">6/8</option>
+                                </select>
+                            </div>
+                            <div class="control-item checkbox-item">
+                                <input type="checkbox" id="include32ndNotes" name="include32ndNotes">
+                                <label for="include32ndNotes">Include 32nd Notes</label>
                             </div>
                         </div>
                     </div>
-                </section>
-            </aside>
 
-            <section class="stave-column" aria-label="Playback and saved jingles">
-                <div class="glass-card playback-card">
-                    <div class="button-row">
-                        <button id="export-music-staff" class="styled-button secondary-action">Export</button>
-                        <button id="delete-all-jingles" class="styled-button danger-action">Delete All</button>
-                    </div>
-                    <div class="musical-staff">
-                        <div class="vexbox">
-                            <div id="musicalstaff"></div>
+                    <div class="control-section">
+                        <h3>Audio Settings</h3>
+                        <div class="control-group">
+                            <div class="control-item">
+                                <label for="synthType">Synthesizer</label>
+                                <select id="synthType">
+                                    <option value="Synth">Synth</option>
+                                    <option value="AMSynth">AMSynth</option>
+                                    <option value="FMSynth">FMSynth</option>
+                                    <option value="MonoSynth">MonoSynth</option>
+                                    <option value="DuoSynth">DuoSynth</option>
+                                    <option value="MetalSynth">MetalSynth</option>
+                                </select>
+                            </div>
+                            <div class="control-item">
+                                <label for="oscillatorType">Oscillator</label>
+                                <select id="oscillatorType">
+                                    <option value="sine">sine</option>
+                                    <option value="square">square</option>
+                                    <option value="triangle">triangle</option>
+                                    <option value="sawtooth">sawtooth</option>
+                                    <option value="pwm">pwm</option>
+                                </select>
+                            </div>
                         </div>
                     </div>
                 </div>
+            </section>
 
-                <section class="glass-card library" aria-labelledby="library-heading">
-                    <div class="library-header">
-                        <h2 id="library-heading">Saved Jingles</h2>
-                        <p>Revisit your compositions and rework them on the fly.</p>
+            <section class="glass-card playback-card" aria-label="Playback controls and musical staff">
+                <div class="button-row">
+                    <button id="export-music-staff" class="styled-button secondary-action">Export</button>
+                    <button id="delete-all-jingles" class="styled-button danger-action">Delete All</button>
+                </div>
+                <div class="musical-staff">
+                    <div class="vexbox">
+                        <div id="musicalstaff"></div>
                     </div>
-                    <ul id="savedJingles">
-                        <div id="savedJinglesDisplay"></div>
-                    </ul>
-                </section>
+                </div>
+            </section>
+
+            <section class="glass-card library" aria-labelledby="library-heading">
+                <div class="library-header">
+                    <h2 id="library-heading">Saved Jingles</h2>
+                    <p>Revisit your compositions and rework them on the fly.</p>
+                </div>
+                <ul id="savedJingles">
+                    <div id="savedJinglesDisplay"></div>
+                </ul>
             </section>
         </section>
     </main>

--- a/jingler.js
+++ b/jingler.js
@@ -466,6 +466,10 @@ function displaySavedJingles() {
         const listItem = document.createElement('li');
         listItem.className = 'saved-jingle-card';
 
+        const notesContainer = document.createElement('span');
+        notesContainer.className = 'saved-jingle-notes';
+        listItem.appendChild(notesContainer);
+
         const actionsContainer = document.createElement('div');
         actionsContainer.className = 'jingle-actions';
 
@@ -493,8 +497,6 @@ function displaySavedJingles() {
         listItem.appendChild(actionsContainer);
 
         // add jingle
-        const notesContainer = document.createElement('span');
-        notesContainer.className = 'saved-jingle-notes';
         jingle.filter(note => !note.resting).forEach(note => {
             // Create a select element
             const noteSelect = document.createElement('select');
@@ -529,7 +531,6 @@ function displaySavedJingles() {
             noteIcon.className = 'small-note-icon'; // Add a class for styling if needed
             notesContainer.appendChild(noteIcon);
         });
-        listItem.appendChild(notesContainer);
         listElement.appendChild(listItem);
     });
 }

--- a/styles/style.css
+++ b/styles/style.css
@@ -193,10 +193,9 @@ main {
 }
 
 .app-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+    display: flex;
+    flex-direction: column;
     gap: var(--spacing-xl);
-    align-items: start;
 }
 
 .glass-card {
@@ -208,13 +207,22 @@ main {
     backdrop-filter: blur(18px);
 }
 
-.params-summary {
+.params-panel {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-md);
+    gap: var(--spacing-lg);
+    width: 100%;
+}
+
+.params-bar {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing-lg);
+    flex-wrap: wrap;
 }
 
 .params-display {
+    flex: 1 1 320px;
     display: flex;
     flex-wrap: wrap;
     gap: var(--spacing-sm) var(--spacing-lg);
@@ -227,7 +235,6 @@ main {
 }
 
 .settings-toggle {
-    align-self: flex-start;
     background: linear-gradient(120deg, rgba(59, 130, 246, 0.2), rgba(124, 58, 237, 0.2));
     border: 1px solid rgba(56, 189, 248, 0.35);
     border-radius: var(--radius-sm);
@@ -237,6 +244,10 @@ main {
     padding: var(--spacing-xs) var(--spacing-md);
     cursor: pointer;
     transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.params-bar .settings-toggle {
+    margin-left: auto;
 }
 
 .settings-toggle:hover,
@@ -255,15 +266,12 @@ main {
     background: linear-gradient(120deg, rgba(236, 72, 153, 0.2), rgba(251, 191, 36, 0.2));
 }
 
-.controls-shell {
-    padding: 0;
-}
-
 .controls-container {
     display: none;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: var(--spacing-lg);
-    padding: var(--spacing-lg);
+    padding-top: var(--spacing-lg);
+    border-top: 1px solid rgba(148, 163, 184, 0.2);
 }
 
 .control-section {
@@ -401,6 +409,7 @@ main {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-lg);
+    width: 100%;
 }
 
 .musical-staff {
@@ -423,6 +432,7 @@ main {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-lg);
+    width: 100%;
 }
 
 .library-header h2 {
@@ -446,6 +456,7 @@ ul {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-md);
+    width: 100%;
 }
 
 #savedJinglesDisplay li {
@@ -455,8 +466,9 @@ ul {
 .saved-jingle-card {
     position: relative;
     display: flex;
-    flex-direction: column;
-    gap: var(--spacing-sm);
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--spacing-md);
     padding: var(--spacing-md);
     background: linear-gradient(135deg, rgba(248, 250, 252, 0.96), rgba(226, 232, 240, 0.9));
     border-radius: var(--radius-md);
@@ -486,6 +498,7 @@ ul {
     flex-wrap: wrap;
     gap: var(--spacing-sm);
     align-items: center;
+    margin-left: auto;
 }
 
 .jingle-action {
@@ -539,6 +552,7 @@ ul {
     flex-wrap: wrap;
     gap: var(--spacing-sm);
     align-items: center;
+    flex: 1 1 260px;
 }
 
 .note-select {
@@ -579,14 +593,16 @@ ul {
     .button-row {
         justify-content: center;
     }
+}
 
-    .app-grid {
-        grid-template-columns: 1fr;
+@media (max-width: 900px) {
+    .params-bar {
+        flex-direction: column;
+        align-items: stretch;
     }
 
-    .controls-column,
-    .stave-column {
-        display: contents;
+    .params-bar .settings-toggle {
+        width: 100%;
     }
 }
 
@@ -605,7 +621,7 @@ ul {
     }
 
     .controls-container {
-        padding: var(--spacing-md);
+        padding-top: var(--spacing-md);
     }
 
     .button-row {
@@ -615,6 +631,12 @@ ul {
     .styled-button {
         width: 100%;
         text-align: center;
+    }
+
+    .jingle-actions {
+        margin-left: 0;
+        width: 100%;
+        justify-content: flex-start;
     }
 }
 


### PR DESCRIPTION
## Summary
- reposition the settings summary and toggle into a single full-width card above the musical staff
- expand the playback and saved-jingle sections to span the workspace and align saved jingle actions inline
- refine supporting styles and responsive tweaks for the updated full-width layout

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690a3e42cb688324a9398ee13a8b3a0c